### PR TITLE
V1.3 undo and redo

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -11,7 +11,6 @@ import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.ModelManager;
 import seedu.address.model.person.Person;
 
 /**

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -64,6 +64,16 @@ public class AddCommand extends Command {
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
     }
 
+    /**
+     * Retrieves the {@code Person} object that is to be added to the address book.
+     * This method allows access to the person specified at the creation of this command.
+     *
+     * @return The {@code Person} object set to be added by this command.
+     */
+    public Person getPersonToAdd() {
+        return toAdd;
+    }
+
     @Override
     public boolean equals(Object other) {
         if (other == this) {

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -11,6 +11,7 @@ import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
 import seedu.address.model.person.Person;
 
 /**
@@ -60,7 +61,7 @@ public class AddCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
         model.addPerson(toAdd);
-
+        model.addExecutedCommand(this);
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -27,7 +27,7 @@ public class ClearCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        addressBookBoforeClear = model.getAddressBook();
+        addressBookBoforeClear = new AddressBook(model.getAddressBook());
         model.setAddressBook(new AddressBook());
         model.addExecutedCommand(this);
         return new CommandResult(MESSAGE_SUCCESS);

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -29,6 +29,7 @@ public class ClearCommand extends Command {
         requireNonNull(model);
         addressBookBoforeClear = model.getAddressBook();
         model.setAddressBook(new AddressBook());
+        model.addExecutedCommand(this);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
+import seedu.address.model.ReadOnlyAddressBook;
 
 /**
  * Clears the address book.
@@ -12,11 +13,21 @@ public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
     public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
+    private ReadOnlyAddressBook addressBookBoforeClear;
 
+    /**
+     * Retrieves the original {@code AddressBook} instance that is targeted to be replaced by an empty one.
+     *
+     * @return The {@code AddressBook} instance that was initially marked to be cleared.
+     */
+    public ReadOnlyAddressBook getAddressBookBeforeClear() {
+        return addressBookBoforeClear;
+    }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
+        addressBookBoforeClear = model.getAddressBook();
         model.setAddressBook(new AddressBook());
         return new CommandResult(MESSAGE_SUCCESS);
     }

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -13,7 +13,7 @@ public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
     public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
-    private ReadOnlyAddressBook addressBookBoforeClear;
+    private ReadOnlyAddressBook addressBookBeforeClear;
 
     /**
      * Retrieves the original {@code AddressBook} instance that is targeted to be replaced by an empty one.
@@ -21,13 +21,13 @@ public class ClearCommand extends Command {
      * @return The {@code AddressBook} instance that was initially marked to be cleared.
      */
     public ReadOnlyAddressBook getAddressBookBeforeClear() {
-        return addressBookBoforeClear;
+        return addressBookBeforeClear;
     }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        addressBookBoforeClear = new AddressBook(model.getAddressBook());
+        addressBookBeforeClear = new AddressBook(model.getAddressBook());
         model.setAddressBook(new AddressBook());
         model.addExecutedCommand(this);
         return new CommandResult(MESSAGE_SUCCESS);

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -32,6 +32,7 @@ public class DeleteCommand extends Command {
 
     private final Id targetId;
 
+    private Person personToDelete;
     private Prompt confirmationBox;
 
     /**
@@ -85,7 +86,7 @@ public class DeleteCommand extends Command {
                 }
                 assert isConfirmed;
 
-                Person personToDelete = person;
+                personToDelete = person;
                 model.deletePerson(personToDelete);
                 isAnyRecordDeleted = true;
                 deletedInformation = Messages.format(personToDelete);
@@ -98,6 +99,16 @@ public class DeleteCommand extends Command {
         }
 
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, deletedInformation));
+    }
+
+    /**
+     * Retrieves the {@code Person} object that is to be deleted from the address book.
+     * This method allows access to the person specified at the creation of this command.
+     *
+     * @return The {@code Person} object set to be deleted by this command.
+     */
+    public Person getPersonToDelete() {
+        return personToDelete;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -98,6 +98,7 @@ public class DeleteCommand extends Command {
             throw new CommandException(String.format(MESSAGE_ID_NOT_FOUND, this.targetId.toString()));
         }
 
+        model.addExecutedCommand(this);
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, deletedInformation));
     }
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -101,6 +101,7 @@ public class EditCommand extends Command {
 
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.addExecutedCommand(this);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -58,6 +58,8 @@ public class EditCommand extends Command {
 
     private final Id id;
     private final EditPersonDescriptor editPersonDescriptor;
+    private Person personToEdit;
+    private Person editedPerson;
 
     /**
      * @param id of the person in the filtered person list to edit
@@ -77,7 +79,7 @@ public class EditCommand extends Command {
         List<Person> lastShownList = model.getFilteredPersonList();
 
         boolean isPersonExist = false;
-        Person personToEdit = new Person(new Name("test"), new Id("test"), new Phone("123"));
+        personToEdit = new Person(new Name("test"), new Id("test"), new Phone("123"));
         for (int i = 0; i < lastShownList.size(); i++) {
             Person currentPerson = lastShownList.get(i);
             if (currentPerson.getId().equals(id)) {
@@ -91,7 +93,7 @@ public class EditCommand extends Command {
         }
         assert !personToEdit.equals(new Person(new Name("test"), new Id("test"), new Phone("123")))
                 : "Should not reach here";
-        Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
+        editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
         if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
@@ -133,6 +135,24 @@ public class EditCommand extends Command {
         EditCommand otherEditCommand = (EditCommand) other;
         return id.equals(otherEditCommand.id)
                 && editPersonDescriptor.equals(otherEditCommand.editPersonDescriptor);
+    }
+
+    /**
+     * Retrieves the original {@code Person} instance that is targeted for editing.
+     *
+     * @return The {@code Person} instance that was initially marked for editing.
+     */
+    public Person getPersonToEdit() {
+        return personToEdit;
+    }
+
+    /**
+     * Retrieves the modified {@code Person} instance after edits have been applied.
+     *
+     * @return The {@code Person} instance that represents the edited state.
+     */
+    public Person getEditedPerson() {
+        return editedPerson;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RedoCommand.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+
+/**
+ * Represents a command with the ability to redo the most recent redone command.
+ * When executed, the command will attempt to restore the address book to its state
+ * after the original action was performed.
+ */
+public class RedoCommand extends Command {
+    public static final String COMMAND_WORD = "redo";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Redo the most recent redone command. ";
+    public static final String MESSAGE_REDO_SUCCESS = "The command: %1$s has been redone.";
+    public static final String MESSAGE_REDO_FAILURE = "There is no more command to redo!";
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (!model.canRedoCommand()) {
+            throw new CommandException(MESSAGE_REDO_FAILURE);
+        }
+
+        model.redoCommand();
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        return new CommandResult(MESSAGE_REDO_SUCCESS);
+    }
+
+}

--- a/src/main/java/seedu/address/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RedoCommand.java
@@ -14,7 +14,7 @@ import seedu.address.model.Model;
 public class RedoCommand extends Command {
     public static final String COMMAND_WORD = "redo";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Redo the most recent redone command. ";
-    public static final String MESSAGE_REDO_SUCCESS = "The command: %1$s has been redone.";
+    public static final String MESSAGE_REDO_SUCCESS = "The command has been redone.";
     public static final String MESSAGE_REDO_FAILURE = "There is no more command to redo!";
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -13,7 +13,7 @@ import seedu.address.model.Model;
 public class UndoCommand extends Command {
     public static final String COMMAND_WORD = "undo";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Undo the last executed command. ";
-    public static final String MESSAGE_UNDO_SUCCESS = "The command: %1$s has been undone.";
+    public static final String MESSAGE_UNDO_SUCCESS = "The command has been undone.";
     public static final String MESSAGE_UNDO_FAILURE = "There is no more command to undo!";
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -20,11 +20,11 @@ public class UndoCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        if (!model.canUndoAddressBook()) {
+        if (!model.canUndoCommand()) {
             throw new CommandException(MESSAGE_UNDO_FAILURE);
         }
 
-        model.undoAddressBook();
+        model.undoCommand();
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(MESSAGE_UNDO_SUCCESS);
     }

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -1,0 +1,32 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+
+/**
+ * Represents a command with the ability to undo the last executed command.
+ * When executed, the command will attempt to revert the address book to the previous state.
+ */
+public class UndoCommand extends Command {
+    public static final String COMMAND_WORD = "undo";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Undo the last executed command. ";
+    public static final String MESSAGE_UNDO_SUCCESS = "The command: %1$s has been undone.";
+    public static final String MESSAGE_UNDO_FAILURE = "There is no more command to undo!";
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (!model.canUndoAddressBook()) {
+            throw new CommandException(MESSAGE_UNDO_FAILURE);
+        }
+
+        model.undoAddressBook();
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        return new CommandResult(MESSAGE_UNDO_SUCCESS);
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,9 +17,9 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
-import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.ToggleDisplayCommand;
+import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,8 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.UndoCommand;
+import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.ToggleDisplayCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -65,6 +67,12 @@ public class AddressBookParser {
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();
+
+        case RedoCommand.COMMAND_WORD:
+            return new RedoCommand();
+
+        case UndoCommand.COMMAND_WORD:
+            return new UndoCommand();
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/model/CommandList.java
+++ b/src/main/java/seedu/address/model/CommandList.java
@@ -115,4 +115,25 @@ public class CommandList {
         model.addPerson(personToAdd);
     }
 
+    //=========== Undo and redo of delete ===================================================================
+
+    /**
+     * Reverses the deletion of a person from the address book.
+     *
+     * @param command The {@code AddCommand} whose effect is to be undone.
+     */
+    private void undoDelete(DeleteCommand command) {
+        Person personDeleted = command.getPersonToDelete();
+        model.addPerson(personDeleted);
+    }
+
+    /**
+     * Re-executes the deletion of a person from the address book.
+     *
+     * @param command The {@code AddCommand} whose effect is to be redone.
+     */
+    private void redoDelete(DeleteCommand command) {
+        Person personToDelete = command.getPersonToDelete();
+        model.addPerson(personToDelete);
+    }
 }

--- a/src/main/java/seedu/address/model/CommandList.java
+++ b/src/main/java/seedu/address/model/CommandList.java
@@ -48,23 +48,47 @@ public class CommandList {
     /**
      * Reverts the most recent command, if possible. This method should only be called if
      * {@link #canUndo()} returns true.
+     * This method identifies the type of the last executed command
+     * and calls the corresponding undo method to reverse its effects.
      *
      * @return true if the operation was successful, false otherwise.
      */
-    public Command undo() {
-        // Method implementation goes here
-        return null;
+    public void undo() {
+        Command lastCommand = commandHistory.get(currentCommandIndex);
+        if (lastCommand instanceof AddCommand) {
+            undoAdd((AddCommand) lastCommand);
+        } else if (lastCommand instanceof DeleteCommand) {
+            undoDelete((DeleteCommand) lastCommand);
+        } else if (lastCommand instanceof EditCommand) {
+            undoEdit((EditCommand) lastCommand);
+        } else if (lastCommand instanceof ClearCommand) {
+            undoClear((ClearCommand) lastCommand);
+        }
+
+        currentCommandIndex--;
     }
 
     /**
      * Reapplies the most recent undone command, if possible. This method should only be called if
      * {@link #canRedo()} returns true.
+     * This method identifies the type of the last executed command
+     * and calls the corresponding undo method to reverse its effects.
      *
      * @return true if the operation was successful, false otherwise.
      */
-    public boolean redo() {
-        // Method implementation goes here
-        return false;
+    public void redo() {
+        Command commandToRedo = commandHistory.get(currentCommandIndex + 1);
+        if (commandToRedo instanceof AddCommand) {
+            redoAdd((AddCommand) commandToRedo);
+        } else if (commandToRedo instanceof DeleteCommand) {
+            redoDelete((DeleteCommand) commandToRedo);
+        } else if (commandToRedo instanceof EditCommand) {
+            redoEdit((EditCommand) commandToRedo);
+        } else if (commandToRedo instanceof ClearCommand) {
+            redoClear((ClearCommand) commandToRedo);
+        }
+
+        currentCommandIndex++;
     }
 
     /**

--- a/src/main/java/seedu/address/model/CommandList.java
+++ b/src/main/java/seedu/address/model/CommandList.java
@@ -1,6 +1,10 @@
 package seedu.address.model;
 
+import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.model.person.Id;
+import seedu.address.model.person.Person;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,10 +18,16 @@ import java.util.List;
 public class CommandList {
     private final List<Command> commandHistory;
     private int currentCommandIndex;
+    private Model model;
+
 
     public CommandList() {
         commandHistory = new ArrayList<>();
         currentCommandIndex = -1; // Indicates that no commands have been executed yet.
+    }
+
+    public void linkToModel(Model model) {
+        this.model = model;
     }
 
     /**
@@ -81,6 +91,28 @@ public class CommandList {
      */
     public boolean canRedo() {
         return commandHistory.size() > currentCommandIndex + 1;
+    }
+
+    //=========== Undo and redo of add ======================================================================
+
+    /**
+     * Reverses the addition of a person to the address book.
+     *
+     * @param command The {@code AddCommand} whose effect is to be undone.
+     */
+    private void undoAdd(AddCommand command) {
+        Person personAdded = command.getPersonToAdd();
+        model.deletePerson(personAdded);
+    }
+
+    /**
+     * Re-executes the addition of a person to the address book.
+     *
+     * @param command The {@code AddCommand} whose effect is to be redone.
+     */
+    private void redoAdd(AddCommand command) {
+        Person personToAdd = command.getPersonToAdd();
+        model.addPerson(personToAdd);
     }
 
 }

--- a/src/main/java/seedu/address/model/CommandList.java
+++ b/src/main/java/seedu/address/model/CommandList.java
@@ -1,10 +1,14 @@
 package seedu.address.model;
 
-import seedu.address.logic.commands.*;
-import seedu.address.model.person.Person;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.model.person.Person;
 
 /**
  * Maintains a list of all executed commands.
@@ -14,13 +18,23 @@ import java.util.List;
  */
 public class CommandList {
     private final List<Command> commandHistory;
+
+    /**
+     * The current index in the {@code commandHistory} list. This index tracks the position
+     * up to which commands have been executed or undone, allowing for correct redo and undo operations.
+     */
     private int currentCommandIndex;
     private Model model;
 
-
+    /**
+     * Constructs a new {@code CommandList} with an empty command history. This setup indicates
+     * that no commands have been executed yet, initializing the current command index to -1
+     * to reflect this state. The command history is initialized as an empty list, ready to
+     * record executed commands for future undo and redo operations.
+     */
     public CommandList() {
         commandHistory = new ArrayList<>();
-        currentCommandIndex = -1; // Indicates that no commands have been executed yet.
+        currentCommandIndex = -1;
     }
 
     public void linkToModel(Model model) {
@@ -46,12 +60,9 @@ public class CommandList {
     }
 
     /**
-     * Reverts the most recent command, if possible. This method should only be called if
-     * {@link #canUndo()} returns true.
+     * Reverts the most recent command, if possible.
      * This method identifies the type of the last executed command
      * and calls the corresponding undo method to reverse its effects.
-     *
-     * @return true if the operation was successful, false otherwise.
      */
     public void undo() {
         Command lastCommand = commandHistory.get(currentCommandIndex);
@@ -69,12 +80,9 @@ public class CommandList {
     }
 
     /**
-     * Reapplies the most recent undone command, if possible. This method should only be called if
-     * {@link #canRedo()} returns true.
+     * Reapplies the most recent undone command, if possible.
      * This method identifies the type of the last executed command
      * and calls the corresponding undo method to reverse its effects.
-     *
-     * @return true if the operation was successful, false otherwise.
      */
     public void redo() {
         Command commandToRedo = commandHistory.get(currentCommandIndex + 1);

--- a/src/main/java/seedu/address/model/CommandList.java
+++ b/src/main/java/seedu/address/model/CommandList.java
@@ -1,10 +1,6 @@
 package seedu.address.model;
 
-import seedu.address.logic.commands.AddCommand;
-import seedu.address.logic.commands.Command;
-import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.EditCommand;
-import seedu.address.model.person.Id;
+import seedu.address.logic.commands.*;
 import seedu.address.model.person.Person;
 
 import java.util.ArrayList;
@@ -139,6 +135,7 @@ public class CommandList {
     }
 
     //=========== Undo and redo of edit =====================================================================
+
     /**
      * Reverses the edit of a person in the address book.
      *
@@ -162,4 +159,30 @@ public class CommandList {
         model.deletePerson(personToEdit);
         model.addPerson(editedPerson);
     }
+
+    //=========== Undo and redo of clear ====================================================================
+
+    /**
+     * Reverses the effect of a clear operation on the address book.
+     * This method restores the state of the address book to what it was before the clear operation
+     * was executed.
+     *
+     * @param command The {@code ClearCommand} whose clearing effect is to be undone.
+     */
+    private void undoClear(ClearCommand command) {
+        ReadOnlyAddressBook addressBookToRestore = command.getAddressBookBeforeClear();
+        model.setAddressBook(addressBookToRestore);
+    }
+
+    /**
+     * Re-executes the clear operation on the address book.
+     * After an undo operation has restored the address book to its previous state, this method
+     * allows for the redo of the clear operation, effectively emptying the address book once again.
+     *
+     * @param command The {@code ClearCommand} that is to be redone, clearing the address book.
+     */
+    private void redoClear(ClearCommand command) {
+        model.setAddressBook(new AddressBook());
+    }
+
 }

--- a/src/main/java/seedu/address/model/CommandList.java
+++ b/src/main/java/seedu/address/model/CommandList.java
@@ -3,6 +3,7 @@ package seedu.address.model;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.EditCommand;
 import seedu.address.model.person.Id;
 import seedu.address.model.person.Person;
 
@@ -120,7 +121,7 @@ public class CommandList {
     /**
      * Reverses the deletion of a person from the address book.
      *
-     * @param command The {@code AddCommand} whose effect is to be undone.
+     * @param command The {@code DeleteCommand} whose effect is to be undone.
      */
     private void undoDelete(DeleteCommand command) {
         Person personDeleted = command.getPersonToDelete();
@@ -130,10 +131,35 @@ public class CommandList {
     /**
      * Re-executes the deletion of a person from the address book.
      *
-     * @param command The {@code AddCommand} whose effect is to be redone.
+     * @param command The {@code DeleteCommand} whose effect is to be redone.
      */
     private void redoDelete(DeleteCommand command) {
         Person personToDelete = command.getPersonToDelete();
         model.addPerson(personToDelete);
+    }
+
+    //=========== Undo and redo of edit =====================================================================
+    /**
+     * Reverses the edit of a person in the address book.
+     *
+     * @param command The {@code EditCommand} whose effect is to be undone.
+     */
+    private void undoEdit(EditCommand command) {
+        Person personToEdit = command.getPersonToEdit();
+        Person editedPerson = command.getEditedPerson();
+        model.deletePerson(editedPerson);
+        model.addPerson(personToEdit);
+    }
+
+    /**
+     * Re-executes the edit of a person in the address book.
+     *
+     * @param command The {@code EditCommand} whose effect is to be redone.
+     */
+    private void redoEdit(EditCommand command) {
+        Person personToEdit = command.getPersonToEdit();
+        Person editedPerson = command.getEditedPerson();
+        model.deletePerson(personToEdit);
+        model.addPerson(editedPerson);
     }
 }

--- a/src/main/java/seedu/address/model/CommandList.java
+++ b/src/main/java/seedu/address/model/CommandList.java
@@ -163,7 +163,7 @@ public class CommandList {
      */
     private void redoDelete(DeleteCommand command) {
         Person personToDelete = command.getPersonToDelete();
-        model.addPerson(personToDelete);
+        model.deletePerson(personToDelete);
     }
 
     //=========== Undo and redo of edit =====================================================================

--- a/src/main/java/seedu/address/model/CommandList.java
+++ b/src/main/java/seedu/address/model/CommandList.java
@@ -1,0 +1,86 @@
+package seedu.address.model;
+
+import seedu.address.logic.commands.Command;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Maintains a list of all executed commands.
+ * This class provides methods to log commands after execution,
+ * and can be utilized to support undo/redo functionality by
+ * keeping track of the command history.
+ */
+public class CommandList {
+    private final List<Command> commandHistory;
+    private int currentCommandIndex;
+
+    public CommandList() {
+        commandHistory = new ArrayList<>();
+        currentCommandIndex = -1; // Indicates that no commands have been executed yet.
+    }
+
+    /**
+     * Adds the executed command to the command history.
+     * This command can later be undone or redone.
+     *
+     * @param command The command that was executed and is to be added to the history.
+     */
+    public void addCommand(Command command) {
+        // Before adding a new command, clear any commands that were executed
+        // after the current command's position in the history.
+        // This is necessary because executing a new command after an undo operation
+        // invalidates the subsequent redo history.
+        while (commandHistory.size() > currentCommandIndex + 1) {
+            commandHistory.remove(commandHistory.size() - 1);
+        }
+        commandHistory.add(command);
+        currentCommandIndex++;
+    }
+
+    /**
+     * Reverts the most recent command, if possible. This method should only be called if
+     * {@link #canUndo()} returns true.
+     *
+     * @return true if the operation was successful, false otherwise.
+     */
+    public Command undo() {
+        // Method implementation goes here
+        return null;
+    }
+
+    /**
+     * Reapplies the most recent undone command, if possible. This method should only be called if
+     * {@link #canRedo()} returns true.
+     *
+     * @return true if the operation was successful, false otherwise.
+     */
+    public boolean redo() {
+        // Method implementation goes here
+        return false;
+    }
+
+    /**
+     * Checks if there are commands available to undo.
+     * This is determined by whether the current command index points to a valid position
+     * within the history list, which means there is at least one executed command that can be undone.
+     *
+     * @return true if there is at least one command that can be undone, false otherwise.
+     */
+    public boolean canUndo() {
+        return currentCommandIndex >= 0;
+    }
+
+    /**
+     * Checks if there are commands available to redo.
+     * This is determined by comparing the size of the command history list with the current command index.
+     * If the size of the list is greater than the current command index + 1, it means there are undone commands
+     * available to be redone.
+     *
+     * @return true if there is at least one command that can be redone, false otherwise.
+     */
+    public boolean canRedo() {
+        return commandHistory.size() > currentCommandIndex + 1;
+    }
+
+}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.logic.commands.Command;
 import seedu.address.model.person.Person;
 
 /**
@@ -104,4 +105,13 @@ public interface Model {
      * Restores the model's address book to its previously undone state.
      */
     void redoCommand();
+
+    /**
+     * Adds the specified command to the command history list.
+     * This method is intended to track commands that have been executed,
+     * allowing for potential undo or redo actions.
+     *
+     * @param command The command that has been executed and is to be added to the history.
+     */
+    void addExecutedCommand(Command command);
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -84,4 +84,24 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    /**
+     * Returns true if the model has previous address book states to restore.
+     */
+    boolean canUndoCommand();
+
+    /**
+     * Returns true if the model has undone address book states to restore.
+     */
+    boolean canRedoCommand();
+
+    /**
+     * Restores the model's address book to its previous state.
+     */
+    void undoCommand();
+
+    /**
+     * Restores the model's address book to its previously undone state.
+     */
+    void redoCommand();
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -11,6 +11,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.logic.commands.Command;
 import seedu.address.model.person.Person;
 
 /**
@@ -153,6 +154,11 @@ public class ModelManager implements Model {
     }
 
     //=========== Undo and redo feature ======================================================================
+
+    @Override
+    public void addExecutedCommand(Command command) {
+        commandList.addCommand(command);
+    }
 
     @Override
     public boolean canUndoCommand() {

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -23,6 +23,8 @@ public class ModelManager implements Model {
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
 
+    private final CommandList commandList;
+
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
      */
@@ -32,6 +34,7 @@ public class ModelManager implements Model {
         logger.fine("Initializing with address book: " + addressBook + " and user prefs " + userPrefs);
 
         this.addressBook = new AddressBook(addressBook);
+        this.commandList = new CommandList();
         this.userPrefs = userPrefs;
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
     }
@@ -146,6 +149,28 @@ public class ModelManager implements Model {
         return addressBook.equals(otherModelManager.addressBook)
                 && userPrefs.equals(otherModelManager.userPrefs)
                 && filteredPersons.equals(otherModelManager.filteredPersons);
+    }
+
+    //=========== Undo and redo feature ======================================================================
+
+    @Override
+    public boolean canUndoCommand() {
+        return commandList.canUndo();
+    }
+
+    @Override
+    public boolean canRedoCommand() {
+        return commandList.canRedo();
+    }
+
+    @Override
+    public void undoCommand() {
+        commandList.undo();
+    }
+
+    @Override
+    public void redoCommand() {
+        commandList.redo();
     }
 
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -35,6 +35,7 @@ public class ModelManager implements Model {
 
         this.addressBook = new AddressBook(addressBook);
         this.commandList = new CommandList();
+        this.commandList.linkToModel(this);
         this.userPrefs = userPrefs;
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
     }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -180,13 +180,28 @@ public class MainWindow extends UiPart<Stage> {
 
     @FXML
     private void handleUndo() throws CommandException, ParseException {
-        logic.execute("undo");
+        try {
+            CommandResult commandResult = logic.execute("undo");
+            logger.info("Result: " + commandResult.getFeedbackToUser());
+            resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
+        } catch (CommandException e) {
+            logger.info("An error occurred while executing command: " + "undo");
+            resultDisplay.setFeedbackToUser(e.getMessage());
+        }
     }
 
     @FXML
     private void handleRedo() throws CommandException, ParseException {
-        logic.execute("redo");
+        try {
+            CommandResult commandResult = logic.execute("redo");
+            logger.info("Result: " + commandResult.getFeedbackToUser());
+            resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
+        } catch (CommandException e) {
+            logger.info("An error occurred while executing command: " + "redo");
+            resultDisplay.setFeedbackToUser(e.getMessage());
+        }
     }
+
 
     public PersonListPanel getPersonListPanel() {
         return personListPanel;

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -43,6 +43,10 @@ public class MainWindow extends UiPart<Stage> {
 
     @FXML
     private MenuItem toggleDisplayMenuItem;
+
+    @FXML
+    private MenuItem EditMenuItem;
+
     @FXML
     private StackPane personListPanelPlaceholder;
 
@@ -172,6 +176,16 @@ public class MainWindow extends UiPart<Stage> {
     @FXML
     private void handleToggleDisplay() {
         personListPanel.toggleDisplay();
+    }
+
+    @FXML
+    private void handleUndo() throws CommandException, ParseException {
+        logic.execute("undo");
+    }
+
+    @FXML
+    private void handleRedo() throws CommandException, ParseException {
+        logic.execute("redo");
     }
 
     public PersonListPanel getPersonListPanel() {

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -45,7 +45,7 @@ public class MainWindow extends UiPart<Stage> {
     private MenuItem toggleDisplayMenuItem;
 
     @FXML
-    private MenuItem EditMenuItem;
+    private MenuItem editMenuItem;
 
     @FXML
     private StackPane personListPanelPlaceholder;

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -34,6 +34,12 @@
           <Menu mnemonicParsing="false" text="View">
             <MenuItem fx:id="toggleDisplayMenuItem" mnemonicParsing="false" onAction="#handleToggleDisplay" text="Toggle Display" />
           </Menu>
+          <Menu mnemonicParsing="false" text="Edit">
+            <items>
+              <MenuItem fx:id="undoMenuItem" mnemonicParsing="false" onAction="#handleUndo" text="Undo"/>
+              <MenuItem fx:id="redoMenuItem" mnemonicParsing="false" onAction="#handleRedo" text="Redo"/>
+            </items>
+          </Menu>
         </MenuBar>
 
         <StackPane VBox.vgrow="NEVER" fx:id="commandBoxPlaceholder" styleClass="pane-with-border">

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -161,6 +161,31 @@ public class AddCommandTest {
         public void updateFilteredPersonList(Predicate<Person> predicate) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public void addExecutedCommand(Command command) {
+            return;
+        }
+
+        @Override
+        public void undoCommand() {
+            return;
+        }
+
+        @Override
+        public void redoCommand() {
+            return;
+        }
+
+        @Override
+        public boolean canUndoCommand() {
+            return false;
+        }
+
+        @Override
+        public boolean canRedoCommand() {
+            return false;
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -18,8 +18,11 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
+import seedu.address.model.person.Id;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 
 /**
@@ -133,4 +136,17 @@ public class CommandTestUtil {
         assertEquals(1, model.getFilteredPersonList().size());
     }
 
+    /**
+     * Adds two people to {@code model}'s address book for test.
+     */
+    public static void addTwoPeople(Model model) {
+        try {
+            Person firstPerson = new Person(new Name("test"), new Id("1234"), new Phone("12345678"));
+            Person secondPerson = new Person(new Name("test"), new Id("12345"), new Phone("12345678"));
+            new AddCommand(firstPerson).execute(model);
+            new AddCommand(secondPerson).execute(model);
+        } catch (CommandException e) {
+            // In test this branch will not be visited.
+        }
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static seedu.address.logic.commands.CommandTestUtil.addTwoPeople;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalIds.ID_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -12,6 +13,9 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.EditPersonDescriptorBuilder;
+import seedu.address.testutil.PersonBuilder;
 
 public class RedoCommandTest {
 
@@ -38,7 +42,7 @@ public class RedoCommandTest {
     }
 
     @Test
-    public void execute() {
+    public void redoAddTest() {
         try {
             new RedoCommand().execute(expectedModel);
         } catch (CommandException e) {
@@ -54,5 +58,38 @@ public class RedoCommandTest {
         assertCommandSuccess(new RedoCommand(), model, RedoCommand.MESSAGE_REDO_SUCCESS, expectedModel);
 
         assertCommandFailure(new RedoCommand(), model, RedoCommand.MESSAGE_REDO_FAILURE);
+    }
+
+    @Test
+    public void redoEditTest() {
+        Person editedPerson = new PersonBuilder().withId(ID_FIRST_PERSON.toString()).build();
+        EditCommand.EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson).build();
+        EditCommand editCommand = new EditCommand(ID_FIRST_PERSON, descriptor);
+
+        try {
+            editCommand.execute(model);
+            editCommand.execute(expectedModel);
+            new UndoCommand().execute(model);
+            new UndoCommand().execute(expectedModel);
+            new RedoCommand().execute(expectedModel);
+        } catch (CommandException e) {
+            // This branch will not be visited.
+        }
+        assertCommandSuccess(new RedoCommand(), model, RedoCommand.MESSAGE_REDO_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void redoClearTest() {
+        new ClearCommand().execute(expectedModel);
+        new ClearCommand().execute(model);
+
+        try {
+            new UndoCommand().execute(expectedModel);
+            new UndoCommand().execute(model);
+            new RedoCommand().execute(expectedModel);
+        } catch (CommandException e) {
+            // This branch will not be visited.
+        }
+        assertCommandSuccess(new RedoCommand(), model, RedoCommand.MESSAGE_REDO_SUCCESS, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
@@ -1,0 +1,58 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.addTwoPeople;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+public class RedoCommandTest {
+
+    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private final Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @BeforeEach
+    public void setUp() {
+        addTwoPeople(model);
+        try {
+            new UndoCommand().execute(model);
+            new UndoCommand().execute(model);
+        } catch (CommandException e) {
+            // This branch will not be visited.
+        }
+
+        addTwoPeople(expectedModel);
+        try {
+            new UndoCommand().execute(expectedModel);
+            new UndoCommand().execute(expectedModel);
+        } catch (CommandException e) {
+            // This branch will not be visited.
+        }
+    }
+
+    @Test
+    public void execute() {
+        try {
+            new RedoCommand().execute(expectedModel);
+        } catch (CommandException e) {
+            // This branch will not be visited.
+        }
+        assertCommandSuccess(new RedoCommand(), model, RedoCommand.MESSAGE_REDO_SUCCESS, expectedModel);
+
+        try {
+            new RedoCommand().execute(expectedModel);
+        } catch (CommandException e) {
+            // This branch will not be visited.
+        }
+        assertCommandSuccess(new RedoCommand(), model, RedoCommand.MESSAGE_REDO_SUCCESS, expectedModel);
+
+        assertCommandFailure(new RedoCommand(), model, RedoCommand.MESSAGE_REDO_FAILURE);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
@@ -12,9 +12,12 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Id;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.EditPersonDescriptorBuilder;
+import seedu.address.testutil.PersonBuilder;
 
 public class UndoCommandTest {
-
     private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
     private final Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
@@ -26,24 +29,50 @@ public class UndoCommandTest {
     }
 
     @Test
-    public void execute() {
+    public void undoAddTest() {
         try {
             new UndoCommand().execute(expectedModel);
         } catch (CommandException e) {
             // This branch will not be visited.
         }
-
         assertCommandSuccess(new UndoCommand(), model, UndoCommand.MESSAGE_UNDO_SUCCESS, expectedModel);
 
         try {
             new UndoCommand().execute(expectedModel);
-            new UndoCommand().execute(expectedModel);
         } catch (CommandException e) {
             // This branch will not be visited.
         }
-
         assertCommandSuccess(new UndoCommand(), model, UndoCommand.MESSAGE_UNDO_SUCCESS, expectedModel);
 
         assertCommandFailure(new UndoCommand(), model, UndoCommand.MESSAGE_UNDO_FAILURE);
+    }
+
+    @Test
+    public void undoClearTest() {
+        new ClearCommand().execute(expectedModel);
+        new ClearCommand().execute(model);
+
+        try {
+            new UndoCommand().execute(expectedModel);
+        } catch (CommandException e) {
+            // This branch will not be visited.
+        }
+        assertCommandSuccess(new UndoCommand(), model, UndoCommand.MESSAGE_UNDO_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void undoEditTest() {
+        Person editedPerson = new PersonBuilder().withId("1234").build();
+        EditCommand.EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson).build();
+        EditCommand editCommand = new EditCommand(new Id("1234"), descriptor);
+
+        try {
+            editCommand.execute(model);
+            editCommand.execute(expectedModel);
+            new UndoCommand().execute(expectedModel);
+        } catch (CommandException e) {
+            // This branch will not be visited.
+        }
+        assertCommandSuccess(new UndoCommand(), model, UndoCommand.MESSAGE_UNDO_SUCCESS, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
@@ -1,0 +1,49 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.addTwoPeople;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+public class UndoCommandTest {
+
+    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private final Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @BeforeEach
+    public void setUp() {
+        addTwoPeople(model);
+
+        addTwoPeople(expectedModel);
+    }
+
+    @Test
+    public void execute() {
+        try {
+            new UndoCommand().execute(expectedModel);
+        } catch (CommandException e) {
+            // This branch will not be visited.
+        }
+
+        assertCommandSuccess(new UndoCommand(), model, UndoCommand.MESSAGE_UNDO_SUCCESS, expectedModel);
+
+        try {
+            new UndoCommand().execute(expectedModel);
+            new UndoCommand().execute(expectedModel);
+        } catch (CommandException e) {
+            // This branch will not be visited.
+        }
+
+        assertCommandSuccess(new UndoCommand(), model, UndoCommand.MESSAGE_UNDO_SUCCESS, expectedModel);
+
+        assertCommandFailure(new UndoCommand(), model, UndoCommand.MESSAGE_UNDO_FAILURE);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -24,7 +24,9 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.ToggleDisplayCommand;
+import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Id;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
@@ -48,6 +50,16 @@ public class AddressBookParserTest {
     public void parseCommand_clear() throws Exception {
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3") instanceof ClearCommand);
+    }
+
+    @Test
+    public void parseCommand_undo() throws Exception {
+        assertTrue(parser.parseCommand(UndoCommand.COMMAND_WORD) instanceof UndoCommand);
+    }
+
+    @Test
+    public void parseCommand_redo() throws Exception {
+        assertTrue(parser.parseCommand(RedoCommand.COMMAND_WORD) instanceof RedoCommand);
     }
 
     @Test


### PR DESCRIPTION
1. Choose `Alternative 2: Individual command knows how to undo/redo by itself` in the DG instead of the suggested structure.   Use a command list to record all the executed commands.

2. Currently supports undo and redo of add, delete, clear and edit commands. Can be easily extended if needed. (such as the `ls` command which hasn't been merged)

3. Imitating the style of Excel, redo and undo can only be clicked in the edit section of the menu bar. Typing redo and undo is ineffective.